### PR TITLE
Search and fetch

### DIFF
--- a/stock-tracker/package-lock.json
+++ b/stock-tracker/package-lock.json
@@ -6316,6 +6316,14 @@
         "minimalistic-crypto-utils": "^1.0.1"
       }
     },
+    "hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "requires": {
+        "react-is": "^16.7.0"
+      }
+    },
     "hosted-git-info": {
       "version": "2.8.8",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
@@ -10613,6 +10621,18 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
+    "react-redux": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.0.tgz",
+      "integrity": "sha512-EvCAZYGfOLqwV7gh849xy9/pt55rJXPwmYvI4lilPM5rUT/1NxuuN59ipdBksRVSvz0KInbPnp4IfoXJXCqiDA==",
+      "requires": {
+        "@babel/runtime": "^7.5.5",
+        "hoist-non-react-statics": "^3.3.0",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.7.2",
+        "react-is": "^16.9.0"
+      }
+    },
     "react-scripts": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/react-scripts/-/react-scripts-3.4.1.tgz",
@@ -10743,6 +10763,11 @@
         "loose-envify": "^1.4.0",
         "symbol-observable": "^1.2.0"
       }
+    },
+    "redux-devtools-extension": {
+      "version": "2.13.8",
+      "resolved": "https://registry.npmjs.org/redux-devtools-extension/-/redux-devtools-extension-2.13.8.tgz",
+      "integrity": "sha512-8qlpooP2QqPtZHQZRhx3x3OP5skEV1py/zUdMY28WNAocbafxdG2tRD1MWE7sp8obGMNYuLWanhhQ7EQvT1FBg=="
     },
     "redux-saga": {
       "version": "1.1.3",

--- a/stock-tracker/package.json
+++ b/stock-tracker/package.json
@@ -8,8 +8,10 @@
     "@testing-library/user-event": "^7.2.1",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
+    "react-redux": "^7.2.0",
     "react-scripts": "3.4.1",
     "redux": "^4.0.5",
+    "redux-devtools-extension": "^2.13.8",
     "redux-saga": "^1.1.3"
   },
   "scripts": {

--- a/stock-tracker/src/App.js
+++ b/stock-tracker/src/App.js
@@ -1,25 +1,39 @@
 import React from 'react';
 import logo from './logo.svg';
+import { createStore, applyMiddleware } from 'redux';
+import { Provider } from 'react-redux';
+import createSagaMiddleware from 'redux-saga'
+import { composeWithDevTools } from 'redux-devtools-extension';
+import SearchBar from './components/SearchBar.js'
+import { rootReducer } from './reducers/rootReducer.js'
+import rootSaga from './sagas/rootSaga.js'
 import './App.css';
+
+const sagaMiddleware = createSagaMiddleware();
+const store = createStore(rootReducer, composeWithDevTools(applyMiddleware(sagaMiddleware)))
+sagaMiddleware.run(rootSaga);
 
 function App() {
   return (
-    <div className="App">
-      <header className="App-header">
-        <img src={logo} className="App-logo" alt="logo" />
-        <p>
-          Edit <code>src/App.js</code> and save to reload.
+    <Provider store={store}>
+      <div className="App">
+        <header className="App-header">
+          <img src={logo} className="App-logo" alt="logo" />
+          <p>
+            Edit <code>src/App.js</code> and save to reload.
         </p>
-        <a
-          className="App-link"
-          href="https://reactjs.org"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Learn React
+          <a
+            className="App-link"
+            href="https://reactjs.org"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Learn React
         </a>
-      </header>
-    </div>
+        <SearchBar />
+        </header>
+      </div>
+    </Provider>
   );
 }
 

--- a/stock-tracker/src/App.js
+++ b/stock-tracker/src/App.js
@@ -18,19 +18,7 @@ function App() {
     <Provider store={store}>
       <div className="App">
         <header className="App-header">
-          <img src={logo} className="App-logo" alt="logo" />
-          <p>
-            Edit <code>src/App.js</code> and save to reload.
-        </p>
-          <a
-            className="App-link"
-            href="https://reactjs.org"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Learn React
-        </a>
-        <SearchBar />
+          <SearchBar />
         </header>
       </div>
     </Provider>

--- a/stock-tracker/src/components/SearchBar.js
+++ b/stock-tracker/src/components/SearchBar.js
@@ -1,0 +1,29 @@
+import React, { useState } from "react";
+import { useDispatch } from 'react-redux'
+
+const SearchBar = () => {
+  const [search, setSearch] = useState("");
+  const dispatch = useDispatch();
+  
+  const handleSubmit = (e) => {
+      e.preventDefault();
+      console.log("Search for " + search + " submitted.");
+      dispatch({ type: 'SEARCH_SUBMITTED', payload: search});
+  }
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <label>
+        Search:
+        <input
+          type="text"
+          value={search}
+          onChange={e => setSearch(e.target.value)}
+        />
+      </label>
+      <input type="submit" value="Submit" />
+    </form>
+  );
+}
+
+export default SearchBar;

--- a/stock-tracker/src/components/SearchBar.js
+++ b/stock-tracker/src/components/SearchBar.js
@@ -7,8 +7,8 @@ const SearchBar = () => {
   
   const handleSubmit = (e) => {
       e.preventDefault();
-      console.log("Search for " + search + " submitted.");
-      dispatch({ type: 'SEARCH_SUBMITTED', payload: search});
+      console.log("Search for " + search.toUpperCase() + " submitted.");
+      dispatch({ type: 'SEARCH_SUBMITTED', payload: search.toUpperCase()});
   }
 
   return (

--- a/stock-tracker/src/config/config.js
+++ b/stock-tracker/src/config/config.js
@@ -1,2 +1,3 @@
 export const BASE_URL = 'https://cloud.iexapis.com/v1/'
 export const NEW_STOCK_ENDPOINT_URL = "http://localhost:8080/normalcolddetails/"
+export const NEWS_ENDPOINT_URL = "http://localhost:8080/normalhotdetails/"

--- a/stock-tracker/src/config/config.js
+++ b/stock-tracker/src/config/config.js
@@ -1,1 +1,2 @@
 export const BASE_URL = 'https://cloud.iexapis.com/v1/'
+export const NEW_STOCK_ENDPOINT_URL = "http://localhost:8080/normalcolddetails/"

--- a/stock-tracker/src/config/config.js
+++ b/stock-tracker/src/config/config.js
@@ -1,3 +1,4 @@
 export const BASE_URL = 'https://cloud.iexapis.com/v1/'
 export const NEW_STOCK_ENDPOINT_URL = "http://localhost:8080/normalcolddetails/"
 export const NEWS_ENDPOINT_URL = "http://localhost:8080/normalhotdetails/"
+export const PRICE_ENDPOINT_URL = "http://localhost:8080/tradehotdetails/"

--- a/stock-tracker/src/reducers/rootReducer.js
+++ b/stock-tracker/src/reducers/rootReducer.js
@@ -3,7 +3,7 @@ const initialState = {
     companyName: "",
     companyOverview: "",
     price: null,
-    news: [], // NOT changed by this reducer
+    news: {}, // NOT changed by this reducer
     keyStats: {} // NOT changed by this reducer
 }
 
@@ -18,6 +18,12 @@ export const rootReducer = (state = initialState, action) => {
                 companyName: stock.companyName,
                 companyOverview: stock.overview.description,
                 price: stock.latestPrice
+            }
+        case 'NEWS_RECEIVED':
+            console.log("news in NEWS_RECEIVED:", action.payload)
+            return {
+                ...state,
+                news: action.payload
             }
 
         default:

--- a/stock-tracker/src/reducers/rootReducer.js
+++ b/stock-tracker/src/reducers/rootReducer.js
@@ -3,7 +3,8 @@ const initialState = {
     companyName: "",
     companyOverview: "",
     price: null,
-    news: {}, // NOT changed by this reducer
+    chart: [],
+    news: [], // NOT changed by this reducer
     keyStats: {} // NOT changed by this reducer
 }
 
@@ -14,10 +15,12 @@ export const rootReducer = (state = initialState, action) => {
             console.log("stock in reducer:", stock)
             return {
                 ...state,
-                stockSymbol: stock.symbol,
+                symbol: stock.symbol,
                 companyName: stock.companyName,
                 companyOverview: stock.overview.description,
-                price: stock.latestPrice
+                price: stock.latestPrice,
+                chart: stock.chart,
+                news: stock.news
             }
         case 'NEWS_RECEIVED':
             console.log("news in NEWS_RECEIVED:", action.payload)
@@ -25,7 +28,13 @@ export const rootReducer = (state = initialState, action) => {
                 ...state,
                 news: action.payload
             }
-
+        case 'PRICE_RECEIVED':
+            console.log("price in PRICE_RECEIVED:", action.payload.latestPrice)        
+            return {
+                ...state,
+                price: action.payload.latestPrice,
+                chart: action.payload.chart
+            }
         default:
             return state;
     }

--- a/stock-tracker/src/reducers/rootReducer.js
+++ b/stock-tracker/src/reducers/rootReducer.js
@@ -1,0 +1,26 @@
+const initialState = {
+    symbol: "",
+    companyName: "",
+    companyOverview: "",
+    price: null,
+    news: [], // NOT changed by this reducer
+    keyStats: {} // NOT changed by this reducer
+}
+
+export const rootReducer = (state = initialState, action) => {
+    switch(action.type) {
+        case 'STOCK_RECEIVED':
+            const stock = action.payload;
+            console.log("stock in reducer:", stock)
+            return {
+                ...state,
+                stockSymbol: stock.symbol,
+                companyName: stock.companyName,
+                companyOverview: stock.overview.description,
+                price: stock.latestPrice
+            }
+
+        default:
+            return state;
+    }
+}

--- a/stock-tracker/src/reducers/rootReducer.js
+++ b/stock-tracker/src/reducers/rootReducer.js
@@ -4,8 +4,8 @@ const initialState = {
     companyOverview: "",
     price: null,
     chart: [],
-    news: [], // NOT changed by this reducer
-    keyStats: {} // NOT changed by this reducer
+    news: [],
+    keyStats: {}
 }
 
 export const rootReducer = (state = initialState, action) => {

--- a/stock-tracker/src/sagas/rootSaga.js
+++ b/stock-tracker/src/sagas/rootSaga.js
@@ -1,5 +1,5 @@
-import { select, put, fork, take, call, takeEvery, takeLatest, cancel, cancelled, race } from 'redux-saga/effects'
-import { NEW_STOCK_ENDPOINT_URL } from '../config/config.js'
+import { select, put, fork, take, call, takeEvery, takeLatest, cancel, cancelled, race, all } from 'redux-saga/effects'
+import { NEW_STOCK_ENDPOINT_URL, NEWS_ENDPOINT_URL } from '../config/config.js'
 
 const getNewStockData = (url) => fetch(url)
     .then(response => response.json())
@@ -13,9 +13,12 @@ function* searchSubmittedHandler(action) {
     const requestParameters = `{"symbol":"${action.payload}", "range":"1d"}`;
     console.log("requestParameters:", requestParameters);
     console.log("URL + PARAMETERS:", NEW_STOCK_ENDPOINT_URL + requestParameters)
-    const newStockData = yield call(getNewStockData, NEW_STOCK_ENDPOINT_URL + requestParameters)
-    console.log("newStockData:", newStockData)
-    yield put({ type: 'STOCK_RECEIVED', payload: newStockData})
+    const { stockData, newsData } = yield all({
+        stockData: call(getNewStockData, NEW_STOCK_ENDPOINT_URL + requestParameters),
+        newsData: call(getNewStockData, NEWS_ENDPOINT_URL + requestParameters)
+        })
+    yield put({ type: 'STOCK_RECEIVED', payload: stockData})
+    yield put({ type: 'NEWS_RECEIVED', payload: newsData})
 }
 
 export default function* rootSaga() {

--- a/stock-tracker/src/sagas/rootSaga.js
+++ b/stock-tracker/src/sagas/rootSaga.js
@@ -32,7 +32,6 @@ function* pollPrice(action) {
     }
     finally {
         if (yield cancelled()) {
-            console.log("in cancel block");
             controller.abort();
         }
     }
@@ -50,7 +49,6 @@ function* pollNews(action) {
     }
     finally {
         if (yield cancelled()) {
-            console.log("in cancel block");
             controller.abort();
         }
     }
@@ -65,7 +63,6 @@ function* searchSubmittedHandler(action) {
         return;
     }
     // Otherwise, cancel current polling requests
-    console.log("Cancelling")
     yield put({ type: 'ABORT_CURRENT_REQUESTS'})
     // Fetch the new stock data
     const requestParameters = `{"symbol":"${symbol}", "range":"1d"}`;

--- a/stock-tracker/src/sagas/rootSaga.js
+++ b/stock-tracker/src/sagas/rootSaga.js
@@ -1,7 +1,7 @@
-import { select, put, fork, take, call, takeEvery, takeLatest, cancel, cancelled, race, all } from 'redux-saga/effects'
-import { NEW_STOCK_ENDPOINT_URL, NEWS_ENDPOINT_URL } from '../config/config.js'
+import { select, put, fork, take, call, takeEvery, takeLatest, cancel, cancelled, race, all, delay } from 'redux-saga/effects'
+import { NEW_STOCK_ENDPOINT_URL, NEWS_ENDPOINT_URL, PRICE_ENDPOINT_URL } from '../config/config.js'
 
-const getNewStockData = (url) => fetch(url)
+const getNewStockData = (url, controller) => fetch(url, { signal: controller.signal })
     .then(response => response.json())
     .catch(error => console.log('Fetch error ', error.name, error.message))
 
@@ -9,19 +9,72 @@ function* searchSubmittedWatcher() {
     yield takeLatest('SEARCH_SUBMITTED', searchSubmittedHandler);
 }
 
+function* stockReceivedWatcher() {
+    while(true) {
+        const action = yield take('STOCK_RECEIVED');
+        const pricePolling = yield fork(pollPrice, action);
+        const newsPolling = yield fork(pollNews, action)
+        yield take('ABORT_CURRENT_REQUESTS');
+        yield cancel(pricePolling);
+        yield cancel(newsPolling);
+    }
+}
+
+function* pollPrice(action) {
+    const controller = new AbortController();
+    const requestParameters = `{"symbol":"${action.payload.symbol}", "range":"1d"}`;
+    try {
+        while(true) {
+            yield delay(3000)
+            const news = yield call(getNewStockData, PRICE_ENDPOINT_URL + requestParameters, controller)
+            yield put({ type: 'PRICE_RECEIVED', payload: news })
+        }
+    }
+    finally {
+        if (yield cancelled()) {
+            console.log("in cancel block");
+            controller.abort();
+        }
+    }
+}
+
+function* pollNews(action) {
+    const controller = new AbortController();
+    const requestParameters = `{"symbol":"${action.payload.symbol}", "range":"1d"}`;
+    try {
+        while(true) {
+            yield delay(3000)
+            const news = yield call(getNewStockData, NEWS_ENDPOINT_URL + requestParameters, controller)
+            yield put({ type: 'NEWS_RECEIVED', payload: news })
+        }
+    }
+    finally {
+        if (yield cancelled()) {
+            console.log("in cancel block");
+            controller.abort();
+        }
+    }
+}
+
 function* searchSubmittedHandler(action) {
-    const requestParameters = `{"symbol":"${action.payload}", "range":"1d"}`;
-    console.log("requestParameters:", requestParameters);
-    console.log("URL + PARAMETERS:", NEW_STOCK_ENDPOINT_URL + requestParameters)
-    const { stockData, newsData } = yield all({
-        stockData: call(getNewStockData, NEW_STOCK_ENDPOINT_URL + requestParameters),
-        newsData: call(getNewStockData, NEWS_ENDPOINT_URL + requestParameters)
-        })
-    yield put({ type: 'STOCK_RECEIVED', payload: stockData})
-    yield put({ type: 'NEWS_RECEIVED', payload: newsData})
+    // Previous and new stock symbols
+    const currentSymbol = yield select(state => state.symbol)
+    const symbol = action.payload;
+    // If search for the same stock as current one, do nothing
+    if (currentSymbol === symbol) {
+        return;
+    }
+    // Otherwise, cancel current polling requests
+    console.log("Cancelling")
+    yield put({ type: 'ABORT_CURRENT_REQUESTS'})
+    // Fetch the new stock data
+    const requestParameters = `{"symbol":"${symbol}", "range":"1d"}`;
+    const controller = new AbortController();
+    const stockData = yield call(getNewStockData, NEW_STOCK_ENDPOINT_URL + requestParameters, controller)
+    yield put({ type: 'STOCK_RECEIVED', payload: stockData }) // this orchestrates the ongoing polls
 }
 
 export default function* rootSaga() {
     yield fork(searchSubmittedWatcher)
-    //yield fork(searchSubmittedHandler)
+    yield fork(stockReceivedWatcher)
 }

--- a/stock-tracker/src/sagas/rootSaga.js
+++ b/stock-tracker/src/sagas/rootSaga.js
@@ -1,4 +1,4 @@
-import { select, put, fork, take, call, takeEvery, takeLatest, cancel, cancelled, race, all, delay } from 'redux-saga/effects'
+import { select, put, fork, take, call, takeLatest, cancel, cancelled, delay } from 'redux-saga/effects'
 import { NEW_STOCK_ENDPOINT_URL, NEWS_ENDPOINT_URL, PRICE_ENDPOINT_URL } from '../config/config.js'
 
 const getNewStockData = (url, controller) => fetch(url, { signal: controller.signal })
@@ -67,13 +67,12 @@ function* searchSubmittedHandler(action) {
     if (currentSymbol === symbol) {
         return;
     }
-    // Otherwise, cancel current polling requests
     // Fetch the new stock data
     const requestParameters = `{"symbol":"${symbol}", "range":"1d"}`;
     const controller = new AbortController();
-    const stockData = yield call(getNewStockData, NEW_STOCK_ENDPOINT_URL + requestParameters, controller)
+    const stockData = yield call(getNewStockData, NEW_STOCK_ENDPOINT_URL + requestParameters, controller);
     if (stockData === undefined) {
-        return
+        return;
     }
     yield put({ type: 'ABORT_CURRENT_REQUESTS' })
     yield put({ type: 'STOCK_RECEIVED', payload: stockData }) // this orchestrates the ongoing polls

--- a/stock-tracker/src/sagas/rootSaga.js
+++ b/stock-tracker/src/sagas/rootSaga.js
@@ -1,0 +1,24 @@
+import { select, put, fork, take, call, takeEvery, takeLatest, cancel, cancelled, race } from 'redux-saga/effects'
+import { NEW_STOCK_ENDPOINT_URL } from '../config/config.js'
+
+const getNewStockData = (url) => fetch(url)
+    .then(response => response.json())
+    .catch(error => console.log('Fetch error ', error.name, error.message))
+
+function* searchSubmittedWatcher() {
+    yield takeLatest('SEARCH_SUBMITTED', searchSubmittedHandler);
+}
+
+function* searchSubmittedHandler(action) {
+    const requestParameters = `{"symbol":"${action.payload}", "range":"1d"}`;
+    console.log("requestParameters:", requestParameters);
+    console.log("URL + PARAMETERS:", NEW_STOCK_ENDPOINT_URL + requestParameters)
+    const newStockData = yield call(getNewStockData, NEW_STOCK_ENDPOINT_URL + requestParameters)
+    console.log("newStockData:", newStockData)
+    yield put({ type: 'STOCK_RECEIVED', payload: newStockData})
+}
+
+export default function* rootSaga() {
+    yield fork(searchSubmittedWatcher)
+    //yield fork(searchSubmittedHandler)
+}


### PR DESCRIPTION
This PR implements card #335. It adds the following functionality:

- A simple, non-styled search bar

- A user can enter a stock symbol in the search bar. If it's a valid one, the application:

   1. Makes a fetch for all the initial data related to that stock (price, company overview, chart data, etc.)
   2. Continues polling the proxy for "real-time" data every 3s. Currently we only continue updating price, chart, and news data, but in principle this can easily be extended to continue fetching any data (each stream of data is handled as a separate process in the real-time phase).

- The user can then change the stock he wants to see at any time by submitting another search.

Right now, this functionality handles basic errors (e.g. invalid stock symbol submitted), but still needs to be made more resilient in future iterations.


