### PR TITLE
Null values in key stats fixed, new APIs added

### DIFF
--- a/stock-tracker/.gitignore
+++ b/stock-tracker/.gitignore
@@ -1,5 +1,8 @@
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
 
+#secrete
+/server/config.js
+
 # dependencies
 /node_modules
 /.pnp

--- a/stock-tracker/server/index.js
+++ b/stock-tracker/server/index.js
@@ -294,6 +294,125 @@ app.get("/tradehotdetails/:request", function (req, resolve) {
       });
   })
 
+  app.get("/hotchart/:request", function (req, resolve) {
+    const request = JSON.parse(req.params.request)
+    let symbol = request.symbol
+    let hotChartUrl = base_url+'stable/stock/'+symbol+'/intraday-prices?token='+secret_key
+    
+    https.get(hotChartUrl, res => {
+        if(res.statusCode==404)
+            resolve.status(404).send('Stock not found');
+        else{
+              //res.setEncoding("utf8");
+              let body = "";
+              res.on("data", data => {
+              body += data;
+              });
+              res.on("end", () => {
+              body = JSON.parse(body);
+              
+              resolve.send(body)
+              });
+            }
+        
+      });
+  })
+
+  app.get("/coldchart/:request", function (req, resolve) {
+    const request = JSON.parse(req.params.request)
+    let symbol = request.symbol
+    let onedayChartUrl = base_url+'stable/stock/'+symbol+'/chart/1d?token='+secret_key
+    let fivedayChartUrl = base_url+'stable/stock/'+symbol+'/chart/5d?token='+secret_key
+    let onemonthChartUrl = base_url+'stable/stock/'+symbol+'/chart/1m?token='+secret_key
+    let oneyearChartUrl = base_url+'stable/stock/'+symbol+'/chart/1y?token='+secret_key
+    let fiveyearChartUrl = base_url+'stable/stock/'+symbol+'/chart/5y?token='+secret_key
+    let maxChartUrl = base_url+'stable/stock/'+symbol+'/chart/max?token='+secret_key
+    https.get(onedayChartUrl, res => {
+        if(res.statusCode==404)
+            resolve.status(404).send('Stock not found');
+        else{
+              //res.setEncoding("utf8");
+              let body = {};
+              let body0 = "";
+              res.on("data", data => {
+              body0 += data;
+              });
+              res.on("end", () => {
+              
+              body.oneday = JSON.parse(body0);
+              
+              https.get(fivedayChartUrl, res1 => {
+                res1.setEncoding("utf8");
+                let body1 =""
+                res1.on("data", data => {
+                body1 += data;
+                
+                });
+                res1.on("end", () => {
+                    body.fiveday = JSON.parse(body1);
+                    
+                    https.get(onemonthChartUrl, res2 => {
+                    res2.setEncoding("utf8");
+                    let body2 =""
+                    res2.on("data", data => {
+                        body2 += data;
+                        
+                    });
+                    res2.on("end", () => {
+                        body.onemonth = JSON.parse(body2)
+                
+                        https.get(oneyearChartUrl, res3 => {
+                        res3.setEncoding("utf8");
+                        let body3 =""
+                        res3.on("data", data => {
+                            body3 += data;
+                            
+                        });
+                        res3.on("end", () => {
+                            body.oneyear = JSON.parse(body3);
+                            
+                            https.get(fiveyearChartUrl, res4 => {
+                                
+                                res4.setEncoding("utf8");
+                                let body4 = "";
+                                res4.on("data", data => {
+                                body4 += data;
+                                
+                                });
+                                res4.on("end", () => {
+                                body.fiveyear = JSON.parse(body4);
+                                
+                                
+                                https.get(maxChartUrl, res5 => {
+                                  res5.setEncoding("utf8");
+                                  let body5 =""
+                                  res5.on("data", data => {
+                                    body5 += data;
+                                    
+                                  });
+                                  res5.on("end", () => {
+                                    body.max = JSON.parse(body5);
+                                   
+                                    
+                                    resolve.send(body)
+                                  });
+                                });
+                                });
+                                
+                                
+                              });
+                        });
+                        });
+                    });
+                    });
+                });
+                });
+              });
+            }
+        
+      });
+  })
+
 app.get("*", (_, res) => {
   res.sendFile(path.join(__dirname, "../../build/index.html"))
 })

--- a/stock-tracker/src/components/components.css
+++ b/stock-tracker/src/components/components.css
@@ -124,7 +124,17 @@ ul {
 }
   
 .title{
-    color:#7fb3ff;
+    width: 221px;
+    height: 19px;
+    font-family: Lato;
+    font-size: 16px;
+    font-weight: bold;
+    font-stretch: normal;
+    font-style: normal;
+    line-height: normal;
+    letter-spacing: normal;
+    text-align: left;
+    color: #7fb3ff;
 }
 
 li{

--- a/stock-tracker/src/components/keyStats.js
+++ b/stock-tracker/src/components/keyStats.js
@@ -1,23 +1,33 @@
 import React from "react";
 import { useSelector } from 'react-redux'
+import { createSelector } from 'reselect'
+import {findHighValue, findLowValue} from '../util'
 import './components.css';
 
 const Keystats = () => {
     const stats = useSelector(state => state.keyStats);
-    
+    const chartData = state => state.chart
+    const openSelector = createSelector(
+        chartData,
+        (chart) => (chart[1]?.open)
+      )
+    const lowHighSelector = createSelector(
+        chartData,
+        (chart) => (findLowValue(chart)+'-'+findHighValue(chart))
+      )
     return (
         <div className="keystats">
             <div className="title">KEY STATS</div>
             <ul className="leftstats">
                 <li>Previous Close{stats.previousClose}</li>
-                <li>Day Range{stats.low+'-'+stats.high}</li>
+                <li>Day Range{useSelector(lowHighSelector)}</li>
                 <li>Volume{stats.iexVolume}</li>
                 <li>Market Cap{stats.marketCap}</li>
                 <li>P/E Ratio{stats.peRatio}</li>
             </ul>
 
             <ul className="rightstats">
-                <li>Open{stats.open}</li>
+                <li>Open{useSelector(openSelector)}</li>
                 <li>52 Week Range{stats.week52Low+'-'+stats.week52High}</li>
                 <li>Total Avg Volume{stats.avgTotalVolume}</li>
                 <li>Earnings Per Share{stats.ttmEPS}</li>

--- a/stock-tracker/src/util.js
+++ b/stock-tracker/src/util.js
@@ -1,5 +1,5 @@
 export function unixToTimePassed(someDateInThePast) {
-    var difference = Date.now() - someDateInThePast;
+    let difference = Date.now() - someDateInThePast;
   
     if (difference < 5 * 1000) {
       return "just now";
@@ -44,3 +44,24 @@ export function unixToTimePassed(someDateInThePast) {
       return result + " ago";
     }
   }
+
+export function findHighValue(chart){
+    let max = 0; 
+    chart.forEach(point => {
+        if(point.average>max){
+            max= point.average
+        }
+   });
+   return max;
+}
+
+export function findLowValue(chart){
+    let min = Number.MAX_VALUE; 
+    
+    chart.forEach(point => {
+        if(point.average<min&&point.average!==null){
+            min= point.average
+        }
+   });
+   return min;
+}


### PR DESCRIPTION
I derived the three null values (open, low and high) from known data to fix the bug of null values. Also, the back end part has two new APIs which provide only chart data. This makes us change the range of chart in front end easier. I have not deleted the chart data from previous APIs to avoid error for the time being, but they will be deleted soon. 
![Annotation 2020-07-20 110038](https://user-images.githubusercontent.com/25446092/87952837-4625f380-ca78-11ea-85d6-a9b4604be549.png)
